### PR TITLE
BF: Fix ioHub finding eyetracker

### DIFF
--- a/psychopy_eyetracker_gazepoint/gazepoint/gp3/default_eyetracker.yaml
+++ b/psychopy_eyetracker_gazepoint/gazepoint/gp3/default_eyetracker.yaml
@@ -1,4 +1,4 @@
-eyetracker.hw.gazepoint.gp3.EyeTracker:
+eyetracker.gazepoint.gp3.EyeTracker:
     # Indicates if the device should actually be loaded at experiment runtime.
     enable: True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ tests = [
 where = ["", "psychopy_eyetracker_gazepoint",]
 
 [project.entry-points."psychopy.iohub.devices.eyetracker"]
-gazepoint = "psychopy_eyetracker_gazepoint.gazepoint"
+gp3 = "psychopy_eyetracker_gazepoint.gazepoint.gp3"
 
 [tool.setuptools.package-data]
 "*" = ["*.yaml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,11 +48,8 @@ tests = [
 [tool.setuptools.packages.find]
 where = ["", "psychopy_eyetracker_gazepoint",]
 
-[project.entry-points."psychopy.iohub.devices"]
-EyeTracker = "psychopy_eyetracker_sr_research.sr_research.eyelink.eyetracker:EyeTracker"
-
 [project.entry-points."psychopy.iohub.devices.eyetracker"]
-EyeTracker = "psychopy_eyetracker_sr_research.sr_research.eyelink.eyetracker:EyeTracker"
+gazepoint = "psychopy_eyetracker_gazepoint.gazepoint"
 
 [tool.setuptools.package-data]
 "*" = ["*.yaml"]


### PR DESCRIPTION
In conjunction with [this PR](https://github.com/psychopy/psychopy/pull/6574) to PsychoPy, these changes allow ioHub to find the eyetracker class and its associated YAML via its entry point into PsychoPy.